### PR TITLE
fix: database layer correctness issues

### DIFF
--- a/internal/database/create.go
+++ b/internal/database/create.go
@@ -40,7 +40,6 @@ func (d *Driver) CreateChapter(chapterID, num, title string, manga *ent.Manga) e
 		SetNum(num).
 		SetManga(manga).
 		SetRegisteredOn(time.Now())
-	// TODO Add created time here
 
 	if title != "" {
 		builder.SetTitle(title)

--- a/internal/database/driver.go
+++ b/internal/database/driver.go
@@ -43,7 +43,7 @@ func GetDriver() (*Driver, error) {
 				config.Postgres.Host, config.Postgres.Port, config.Postgres.User, config.Postgres.Password,
 				config.Postgres.SSLMode, config.Postgres.Opts)
 
-			if err := postgresql.CreateDatabase("mangathr", psqlConnInfo); err != nil {
+			if err := postgresql.CreateDatabase(config.Postgres.DbName, psqlConnInfo); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/database/postgresql/driver.go
+++ b/internal/database/postgresql/driver.go
@@ -2,9 +2,8 @@ package postgresql
 
 import (
 	"database/sql"
-	"fmt"
 	"github.com/browningluke/mangathr/v2/internal/logging"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
 func CreateDatabase(dbName, connInfo string) error {
@@ -13,28 +12,37 @@ func CreateDatabase(dbName, connInfo string) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
-	logging.Debugln("Executing db search SQL command")
-	existsResult, err := db.Exec(
-		fmt.Sprintf("SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('%s');", dbName))
+	// Check whether the database already exists.
+	// db.Exec on a SELECT returns 0 RowsAffected regardless of result count
+	// with the pq driver, so we use QueryRow with EXISTS instead.
+	var exists bool
+	logging.Debugln("Checking if database exists")
+	err = db.QueryRow(
+		"SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_database WHERE lower(datname) = lower($1))",
+		dbName,
+	).Scan(&exists)
 	if err != nil {
 		return err
 	}
 
-	rowsAffected, err := existsResult.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	// If database doesn't exist, create it
-	if rowsAffected == 0 {
-		logging.Debugln("Executing db create SQL command")
-		_, err = db.Exec(fmt.Sprintf("create database %s", dbName))
-		if err != nil {
-			return err
-		}
-	} else {
+	if exists {
 		logging.Debugln("Skipping creation. Database already exists")
+		return nil
+	}
+
+	logging.Debugln("Executing db create SQL command")
+	// pq.QuoteIdentifier safely quotes the identifier to prevent injection.
+	_, err = db.Exec("CREATE DATABASE " + pq.QuoteIdentifier(dbName))
+	if err != nil {
+		// 42P04 = duplicate_database; harmless race where another process
+		// created the DB between our existence check and this CREATE.
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "42P04" {
+			logging.Debugln("Database created concurrently, ignoring duplicate error")
+			return nil
+		}
+		return err
 	}
 
 	return nil

--- a/internal/database/query.go
+++ b/internal/database/query.go
@@ -17,7 +17,7 @@ func (d *Driver) queryManga(eager bool, ps ...predicate.Manga) (*ent.Manga, erro
 
 	u, err := mq.Only(d.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed querying user: %w", err)
+		return nil, fmt.Errorf("failed querying manga: %w", err)
 	}
 	logging.Debugln("manga returned: ", u)
 	return u, nil
@@ -53,7 +53,7 @@ func (d *Driver) QueryAllManga() ([]*ent.Manga, error) {
 		WithChapters().
 		All(d.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed querying user: %w", err)
+		return nil, fmt.Errorf("failed querying manga: %w", err)
 	}
 	logging.Debugln("manga returned: ", u)
 	return u, nil

--- a/internal/database/sqlite3/driver.go
+++ b/internal/database/sqlite3/driver.go
@@ -24,7 +24,7 @@ func (d sqliteDriver) Open(name string) (driver.Conn, error) {
 	})
 	if _, err := c.Exec("PRAGMA foreign_keys = on;", nil); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("%s%s", err, " failed to enable enable foreign keys")
+		return nil, fmt.Errorf("%s%s", err, " failed to enable foreign keys")
 	}
 	return conn, nil
 }

--- a/internal/database/update.go
+++ b/internal/database/update.go
@@ -11,7 +11,7 @@ import (
 func (d *Driver) UpdateManga(mangaUpdate *ent.MangaUpdateOne) (*ent.Manga, error) {
 	manga, err := mangaUpdate.Save(d.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating manga: %w", err)
+		return nil, fmt.Errorf("failed updating manga: %w", err)
 	}
 	logging.Debugln("manga was updated: ", manga)
 	return manga, nil
@@ -23,12 +23,12 @@ func (d *Driver) DeleteManga(m *ent.Manga) error {
 		Where(chapter.HasMangaWith(manga.MangaID(m.MangaID))).
 		Exec(d.ctx)
 	if err != nil {
-		return fmt.Errorf("failed deleting chapters for manga %w", err)
+		return fmt.Errorf("failed deleting chapters for manga: %w", err)
 	}
 
 	err = d.client.Manga.DeleteOne(m).Exec(d.ctx)
 	if err != nil {
-		return fmt.Errorf("failed deleting manga %w", err)
+		return fmt.Errorf("failed deleting manga: %w", err)
 	}
 	logging.Debugln("manga was deleted: ", m)
 	return nil


### PR DESCRIPTION
- **postgresql**: `Exec`+`RowsAffected` on a SELECT always returns 0 with the `pq` driver; replaced with `QueryRow`+`EXISTS`. Added `defer db.Close()`, `pq.QuoteIdentifier` for the CREATE, and a 42P04 guard for concurrent creation races.
- **driver**: `CreateDatabase` was called with a hardcoded `"mangathr"` string instead of the configured `dbName`.
- **sqlite3**: typo "enable enable" → "enable".
- **query**: error strings said "querying user" instead of "querying manga".
- **update**: `UpdateManga` error said "creating"; two `Errorf` strings missing `:` before `%w`.
- **create**: removed stale TODO (field already set).