### PR TITLE
fix: replace panics with proper error handling; guard nil ScraperError.Error

### DIFF
--- a/cmd/mangathr/config/config.go
+++ b/cmd/mangathr/config/config.go
@@ -27,7 +27,7 @@ func NewCmd(getConfigPath func() string) *cobra.Command {
 			if o.Edit {
 				err := editConfig(configPath)
 				if err != nil {
-					panic(err)
+					ui.Fatalf("Failed to edit config: %s\n", err)
 				}
 			}
 
@@ -35,7 +35,7 @@ func NewCmd(getConfigPath func() string) *cobra.Command {
 			if o.Show {
 				err := showFile(configPath)
 				if err != nil {
-					panic(err)
+					ui.Fatalf("Failed to show config: %s\n", err)
 				}
 			}
 

--- a/cmd/mangathr/register/run.go
+++ b/cmd/mangathr/register/run.go
@@ -232,7 +232,9 @@ func handleMenu(args *registerOpts, driver *database.Driver) {
 				for _, c := range chapters {
 					err := driver.CreateChapter(c.ID, c.Metadata.Num, c.Metadata.Title, manga)
 					if err != nil {
-						panic(err)
+						logging.ExitIfErrorWithFunc(&logging.ScraperError{
+							Error: err, Message: "An error occurred when saving chapter to database", Code: 0,
+						}, closeDatabase)
 					}
 				}
 			},

--- a/cmd/mangathr/root.go
+++ b/cmd/mangathr/root.go
@@ -52,9 +52,8 @@ func init() {
 	// Help func
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.SetHelpFunc(func(c *cobra.Command, s []string) {
-		err := c.Usage()
-		if err != nil {
-			panic(err)
+		if err := c.Usage(); err != nil {
+			ui.Fatalf("Failed to display usage: %s\n", err)
 		}
 	})
 	rootCmd.SetHelpCommand(&cobra.Command{Use: "h", Hidden: true})
@@ -118,9 +117,6 @@ func initConfig() {
 }
 
 func setLogLevel(logLevelArg, logLevelConf string) {
-	//fmt.Println("log level arg: ", logLevelArg)
-	//fmt.Println("log level cfg: ", logLevelConf)
-
 	// If neither value is set, do nothing (level has default: logging.loggingLevel)
 	if logLevelArg == "" && logLevelConf == "" {
 		return

--- a/internal/logging/error.go
+++ b/internal/logging/error.go
@@ -16,14 +16,16 @@ func ExitIfError(err *ScraperError) {
 
 func ExitIfErrorWithFunc(err *ScraperError, f func()) {
 	if err != nil {
-		if err.Error.Error() == "interrupt" {
+		if err.Error != nil && err.Error.Error() == "interrupt" {
 			Errorln("Caught SIGINT, exiting safely")
 			f()
 			ui.Fatal("Exiting...")
 			return
 		}
 
-		Errorln(err.Error)
+		if err.Error != nil {
+			Errorln(err.Error)
+		}
 		f()
 		ui.Fatal(err.Message)
 	}

--- a/internal/ui/option.go
+++ b/internal/ui/option.go
@@ -33,6 +33,7 @@ func (o *option) ConfirmationHandler(prompt string, yes, no func(), error func(e
 
 		if err != nil {
 			error(err)
+			return !o.terminate
 		}
 
 		if confirm {
@@ -53,6 +54,7 @@ func (o *option) InputHandler(prompt string, input func(string), error func(erro
 
 		if err != nil {
 			error(err)
+			return !o.terminate
 		}
 
 		input(res)
@@ -70,6 +72,7 @@ func (o *option) CheckboxHandler(prompt string, genOpts func() []string, s func(
 
 		if err != nil {
 			e(err)
+			return !o.terminate
 		}
 
 		s(sel)

--- a/internal/ui/panel.go
+++ b/internal/ui/panel.go
@@ -77,6 +77,7 @@ func (p *panel) Start() bool {
 		index, err := SingleCheckboxesIndex(p.prompt(), optionStrings)
 		if err != nil {
 			p.errorHandler(err)
+			continue
 		}
 
 		selectedOpt := p.options[index]


### PR DESCRIPTION
- **logging/error.go**: `ExitIfErrorWithFunc` calls `err.Error.Error()` without checking if `err.Error` is nil; several callers intentionally pass `Error: nil` (e.g. invalid-source validation). Added nil guards on both the interrupt check and the `Errorln` call.
- **config/config.go**: `panic(err)` on edit/show errors replaced with `ui.Fatalf`.
- **root.go**: `panic(err)` in the help handler replaced with `ui.Fatalf`; removed two stale debug `fmt.Println` comments.
- **register/run.go**: `panic(err)` when persisting chapters to the DB replaced with `ExitIfErrorWithFunc`.
- **ui/option.go**: all three option handlers called the success callback even after the error callback was invoked; added early `return` so invalid state is never forwarded.
- **ui/panel.go**: `SingleCheckboxesIndex` returns `-1` on error; if the error handler does not exit, `p.options[-1]` would panic. Added `continue` to restart the loop.