### PR TITLE
fix: source scraper panics and logic errors

### DIFF
--- a/cmd/mangathr/update/run.go
+++ b/cmd/mangathr/update/run.go
@@ -80,9 +80,7 @@ func checkMangaForNewChapters(manga *ent.Manga) (seriesStats, *logging.ScraperEr
 	// Select new chapters in scraper, get array of them; and download if > 0
 	newChapters, err := scraper.SelectNewChapters(chapterIDs)
 	if err != nil {
-		// Log error, abandon search, and continue (no need to exit program)
-		logging.Errorln(err)
-		ui.Error("An error occurred while search for ", manga.Title)
+		return seriesStats{}, err
 	}
 
 	stats.found = len(newChapters)

--- a/internal/sources/cubari/scraper.go
+++ b/internal/sources/cubari/scraper.go
@@ -104,7 +104,10 @@ func filterGroups(chapters []manga.Chapter, groups []string, exclude bool) []man
 	var filteredChapters []manga.Chapter
 
 	for _, v := range chapters {
-		// Assuming chapters must have 1 and only 1 group (as Cubari does with GIST provider)
+		if len(v.Metadata.Groups) == 0 {
+			continue
+		}
+		// Cubari chapters always have exactly one group entry.
 		_, ok := utils.FindInSlice(groups, v.Metadata.Groups[0])
 
 		// If we're excluding, invert the answer

--- a/internal/sources/mangadex/chapter.go
+++ b/internal/sources/mangadex/chapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"github.com/browningluke/mangathr/v2/internal/manga"
 	"github.com/browningluke/mangathr/v2/internal/rester"
+	"github.com/browningluke/mangathr/v2/internal/utils"
 	"strconv"
 	"strings"
 )
@@ -124,7 +125,7 @@ func (m *Scraper) parseGroups(data mangaFeedData) []string {
 
 	// Add groups to scraper
 	for _, group := range groups {
-		// Check if group already caught my scraper
+		// Check if group has already been captured by this scraper
 		skip := false
 		for _, a := range m.groups {
 			if a == group {
@@ -199,7 +200,7 @@ func (m *Scraper) scrapeChapters() ([]manga.Chapter, *logging.ScraperError) { //
 						Title:    metadataTitle,
 						Num:      numString,
 						Language: item.Attributes.TranslatedLanguage,
-						Date:     item.Attributes.CreatedAt[0:11],
+						Date:     utils.ExtractDate(item.Attributes.CreatedAt),
 						Link:     fmt.Sprintf("https://mangadex.org/chapter/%s", item.Id),
 						Groups:   groups,
 					},

--- a/internal/sources/mangadex/search.go
+++ b/internal/sources/mangadex/search.go
@@ -129,8 +129,8 @@ func (m *Scraper) SelectManga(name string) *logging.ScraperError {
 
 	if !found {
 		return &logging.ScraperError{
-			Error:   fmt.Errorf("selected manga `%s`not in searchResults", name),
-			Message: "An error occurred while selected Manga",
+			Error:   fmt.Errorf("selected manga `%s` not in searchResults", name),
+			Message: "An error occurred while selecting Manga",
 			Code:    0,
 		}
 	}


### PR DESCRIPTION
**mangadex/chapter.go**: `item.Attributes.CreatedAt[0:11]` panics when the API returns a timestamp shorter than 11 characters. Replaced with `utils.ExtractDate`, which already handles malformed dates safely (already used elsewhere in the codebase). Also fixed a comment typo.

**cubari/scraper.go**: `filterGroups` accessed `v.Metadata.Groups[0]` without checking length; added a guard to skip chapters with no groups.

**update/run.go**: `SelectNewChapters` error was logged then silently discarded, letting execution continue with a nil/empty slice. Propagate the error to `checkMangaForNewChapters` so the update loop can skip and report the failed series properly.

**mangadex/search.go**: fixed missing space and verb typo in error string.