### PR TITLE
fix: misc correctness issues and dead code

### DIFF
--- a/cmd/mangathr/download/download.go
+++ b/cmd/mangathr/download/download.go
@@ -54,14 +54,13 @@ func (o *downloadOpts) run(cfg *config.Config) {
 
 	// Search and select manga
 	titles, err := scraper.Search(o.Query)
+	logging.ExitIfError(err)
 
 	// Exit if no manga are found
 	if len(titles) == 0 {
 		ui.PrintlnColor(ui.Yellow, "No manga found with specified query. Exiting...")
 		return
 	}
-
-	logging.ExitIfError(err)
 
 	selection, uierr := ui.SingleCheckboxes("Select Manga:", titles)
 	if uierr != nil {
@@ -76,7 +75,6 @@ func (o *downloadOpts) run(cfg *config.Config) {
 	chapterTitles, err := scraper.ChapterTitles()
 	logging.ExitIfError(err)
 
-	//fmt.Println(chapters)
 	chapterTitle := scraper.MangaTitle()
 	sourceName := scraper.ScraperName()
 	chapterSelections, uierr := SelectChapters(chapterTitles, chapterTitle, sourceName)

--- a/cmd/mangathr/update/update.go
+++ b/cmd/mangathr/update/update.go
@@ -105,6 +105,7 @@ func (o *updateOpts) run(cfg *config.Config) {
 		if durErr != nil {
 			logging.Errorln(durErr)
 			ui.Error("Failed to parse time duration.")
+			continue
 		}
 		time.Sleep(dur)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,10 +121,6 @@ func (c *Config) useDefaults(inContainer bool) {
 	c.Sources.Mangadex = mangadexConf
 
 	c.LogLevel = ""
-
-	// Overwrite defaults if we are in a container
-	if inContainer {
-	}
 }
 
 func (c *Config) validate() error {

--- a/internal/sources/cubari/search.go
+++ b/internal/sources/cubari/search.go
@@ -28,12 +28,15 @@ func (m *Scraper) searchBySlug(slug string) ([]string, *logging.ScraperError) {
 	return []string{m.MangaTitle()}, nil
 }
 
-// matchQuery against different provider regex patters.
+// matchQuery against different provider regex patterns.
+// Returns the slug (capture group 4) when the query matches, or "" otherwise.
 func (m *Scraper) matchQuery(query, reStr string, provider Provider) string {
 	re := regexp.MustCompile(reStr)
 	match := re.FindStringSubmatch(query)
 
-	if len(match) > 0 {
+	// All provider regexes have exactly 4 capture groups; require at least 5
+	// elements (full match + 4 groups) before accessing match[4].
+	if len(match) > 4 {
 		m.provider = provider
 		return match[4]
 	}
@@ -69,7 +72,15 @@ func (m *Scraper) Search(query string) ([]string, *logging.ScraperError) {
 			}
 		}
 
-		m.provider = PROVIDERBYSTR[cbMatch[4]]
+		provider, ok := PROVIDERBYSTR[cbMatch[4]]
+		if !ok {
+			return []string{}, &logging.ScraperError{
+				Error:   fmt.Errorf("unknown cubari provider: %s", cbMatch[4]),
+				Message: "Cubari source does not support the given provider.",
+				Code:    0,
+			}
+		}
+		m.provider = provider
 		slug = cbMatch[5]
 	}
 


### PR DESCRIPTION
**download.go**: `Search()` error was checked *after* the empty-results guard, so a real API failure was silently swallowed and printed as "no manga found". Moved `ExitIfError` before the length check. Removed stale commented-out debug line.

**update/update.go**: `time.Sleep(dur)` ran even when `time.ParseDuration` failed (`dur` is zero, so it was a no-op but still wrong). Added `continue` so the inter-check sleep is skipped on a bad duration string.

**internal/config/config.go**: removed empty `if inContainer {}` dead-code block.

**cubari/search.go**:
- `matchQuery` checked `len(match) > 0` before accessing `match[4]`; all provider regexes have exactly 4 capture groups so the correct guard is `len(match) > 4`.
- `PROVIDERBYSTR[cbMatch[4]]` silently returns a zero-value `Provider` for unknown keys. Added an explicit check and a proper error return.