### PR TITLE
fix(cubari): handle imgchest proxy pages

### DIFF
--- a/internal/sources/cubari/pages.go
+++ b/internal/sources/cubari/pages.go
@@ -14,8 +14,8 @@ func (m *Scraper) addPagesToChapter(chapter *manga.Chapter) *logging.ScraperErro
 	pages := m.pages[chapter.ID]
 
 	// Get pages from proxy URL
-	// (if using GIST provider)
-	if m.provider == GIST {
+	// (if using GIST or IMGCHEST provider)
+	if m.provider == GIST || m.provider == IMGCHEST {
 		// Check if pages contain a valid URL
 		allValid := true
 

--- a/internal/sources/cubari/pages.go
+++ b/internal/sources/cubari/pages.go
@@ -34,11 +34,18 @@ func (m *Scraper) addPagesToChapter(chapter *manga.Chapter) *logging.ScraperErro
 				map[string]string{}, []rester.QueryParam{}).Do(4, "100ms")
 			jsonString := jsonResp.(string)
 
-			urls, ok := parseImgurStyle([]byte(jsonString))
+			// The proxy endpoint returns json.dumps(pages) directly:
+			//   imgur    → [{description, src}, ...]
+			//   imgchest → ["https://...", ...]
+			var urls []string
+			var ok bool
+			if urls, ok = parseImgurStyle([]byte(jsonString)); !ok {
+				urls, ok = parseListStyle([]byte(jsonString))
+			}
 			if !ok {
 				return &logging.ScraperError{
-					Error:   errors.New("failed to get imgur URLs from proxy"),
-					Message: "An error occurred while getting pages from imgur",
+					Error:   errors.New("failed to get image URLs from proxy"),
+					Message: "An error occurred while getting pages from proxy",
 					Code:    0,
 				}
 			}

--- a/internal/sources/cubari/providers.go
+++ b/internal/sources/cubari/providers.go
@@ -35,9 +35,17 @@ var MANGASEE = Provider{
 	registrable: true,
 }
 
+var IMGCHEST = Provider{
+	name:        "imgchest",
+	sourceURL:   "https://imgchest.com",
+	regex:       ``,
+	registrable: true,
+}
+
 var PROVIDERBYSTR = map[string]Provider{
 	"imgur":    IMGUR,
 	"gist":     GIST,
 	"nhentai":  NHENTAI,
 	"mangasee": MANGASEE,
+	"imgchest": IMGCHEST,
 }


### PR DESCRIPTION
Fixes downloads from Cubari GIST sources that contain imgchest chapters.

Cubari's chapter proxy API always returns `json.dumps(pages)` directly. The page format depends on the upstream source:
- **imgur** → `[{"description": "...", "src": "..."}]`
- **imgchest** → `["https://...", ...]`

`addPagesToChapter` only tried `parseImgurStyle`, so imgchest chapters always failed with *"failed to get imgur URLs from proxy"*. This adds `parseListStyle` as a fallback, matching how the MANGASEE proxy path already works.