### PR TITLE
ci: bump Go version to 1.24.x

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go 1.23.x
+      - name: Setup Go 1.24.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
 
       - name: Cross-compile Go programs
         run: |


### PR DESCRIPTION
go.mod was bumped to `go 1.24.0` when upgrading `modernc.org/sqlite` to v1.44.3. The build workflow was still pinned to `1.23.x`, causing `go mod download` to fail with *"go.mod requires go >= 1.24.0"*.