### PR TITLE
fix: update Go to 1.24 in Docker and CI, suppress git errors in Makefile

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go 1.23.x
+      - name: Setup Go 1.24.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
 
       - name: Cross-compile Go programs
         run: |

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ SRC := $(shell find . -type f -name '*.go' -print) go.mod go.sum
 SHELL      = /usr/bin/env sh
 
 # git
-GIT_COMMIT = $(shell git rev-parse HEAD)
-GIT_SHA    = $(shell git rev-parse --short HEAD)
+GIT_COMMIT = $(shell git rev-parse HEAD 2>/dev/null)
+GIT_SHA    = $(shell git rev-parse --short HEAD 2>/dev/null)
 GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 LDFLAGS   += -X github.com/browningluke/mangathr/v2/internal/version.sha=${GIT_SHA}
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM golang:1.23-alpine AS build
+FROM golang:1.24-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The Docker build was failing with two errors:

1. `go: go.mod requires go >= 1.24.0 (running go 1.23.12)` — the Dockerfile used `golang:1.23-alpine` but `go.mod` requires Go 1.24.0
2. `fatal: not a git repository` — the Makefile runs `git rev-parse` during parsing, but Docker builds have no `.git` directory

## Changes

- **`docker/build/Dockerfile`**: Update base image from `golang:1.23-alpine` → `golang:1.24-alpine`
- **`Makefile`**: Redirect stderr to `/dev/null` for `git rev-parse` calls to suppress errors in git-less environments
- **`.github/workflows/go-build.yml`**: Update Go version from `1.23.x` → `1.24.x` to match `go.mod`