### PR TITLE
feat: add hooks system

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ mangathr <COMMAND> -s SOURCE QUERY
 - [Options](#options)
 - [Configuration](#configuration)
 - [Sources](#sources)
+- [Hooks](#hooks)
 - [Databases](#databases)
 - [Metadata Agents](#metadata-agents)
 
@@ -245,9 +246,126 @@ mangaplus:
   split: "no"                # One of: (no|yes) — whether to split spreads
 ```
 
-## Databases
+## Hooks
 
-| Database   | Supported |
+Hooks execute at lifecycle events during `download` and `update` runs. They can call webhooks or run local commands. All hook fields that accept a string payload use Go's [`text/template`](https://pkg.go.dev/text/template).
+
+### Events
+
+| Event | Fires when |
+|---|---|
+| `download.chapter` | A chapter is successfully downloaded (both `download` and `update` commands) |
+| `update.success` | A manga is successfully checked/downloaded during an `update` run |
+| `update.error` | An error occurs while processing a manga during an `update` run |
+
+### Common options
+
+All hook types share these fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | — | Identifies the hook in logs (required) |
+| `on` | list | — | Events that trigger this hook (required) |
+| `aggregate` | bool | `false` | Collect all events and fire once at end of run instead of immediately |
+| `abortOnError` | bool | `false` | Propagate hook failure to abort the current operation |
+| `fireIfEmpty` | bool | `false` | Fire even when no chapters were downloaded |
+
+### Template context
+
+When `aggregate: false`, templates receive a `HookContext`:
+
+```
+.Manga.Title        # Manga title
+.Manga.Source       # Source name (e.g. "mangadex")
+.Chapter.Num        # Chapter number string
+.Chapter.Title      # Chapter title
+.Chapter.Path       # Filesystem path where the chapter was saved
+.Chapter.Lang       # Language code
+.Chapter.Groups     # Comma-separated scanlation group names
+.Chapter.Count      # Number of chapters downloaded in this invocation
+.Error.Message      # Error message (only set for error events; nil otherwise)
+.Event              # Event name that triggered this hook
+```
+
+When `aggregate: true`, templates receive an `AggregateHookContext`:
+
+```
+.Items[]            # Slice of HookContext, one per collected event
+.ChapterCount       # Total chapters across all items
+.ErrorCount         # Number of items with errors
+.MangaCount         # Number of distinct manga titles
+.Event              # Event name of the last collected item
+```
+
+### Discord
+
+Posts a message to a Discord webhook. Set `embed: true` for a rich embed, or `false` for a plain text message.
+
+```yaml
+hooks:
+  discord:
+    - name: "My Discord"
+      webhookURL: "https://discord.com/api/webhooks/..."
+      abortOnError: false
+      fireIfEmpty: false
+      on:
+        - update.success
+      aggregate: true           # fire once with a summary at end of update run
+      embed: true
+      template:
+        title: "mangathr update"
+        description: |
+          {{ range .Items }}• **{{ .Manga.Title }}**: {{ .Chapter.Count }} chapter(s)
+          {{ end }}
+        color: 5814783          # decimal colour value
+        footer: "mangathr"
+        # message: "..."        # used instead of title/description/color/footer when embed: false
+```
+
+### Webhook
+
+Fires a templated HTTP request. The `body` and `headers` fields are `text/template` strings; `headers` must render to a JSON object.
+
+```yaml
+hooks:
+  webhook:
+    - name: "My API"
+      webhookURL: "https://example.com/hook"
+      requestType: POST         # GET / POST / PUT / PATCH (default: POST)
+      successCode: 200
+      abortOnError: false
+      fireIfEmpty: false
+      on:
+        - download.chapter
+      aggregate: false
+      body: |
+        {"manga": "{{ .Manga.Title }}", "chapter": "{{ .Chapter.Num }}", "path": "{{ .Chapter.Path }}"}
+      headers: |
+        {"Authorization": "Bearer TOKEN"}
+```
+
+### Subcommand
+
+Runs a local command. Each entry in `args` and each value in `env` is a `text/template` string.
+
+```yaml
+hooks:
+  subcommand:
+    - name: "Post-process"
+      command: "/usr/local/bin/post-process.sh"
+      abortOnError: true        # abort download if script exits non-zero
+      fireIfEmpty: false
+      on:
+        - download.chapter
+      aggregate: false
+      args:
+        - "{{ .Chapter.Path }}"
+      env:
+        MANGA_TITLE: "{{ .Manga.Title }}"
+        CHAPTER_NUM: "{{ .Chapter.Num }}"
+```
+
+## Databases
 |------------|:---------:|
 | SQLite3    |     ✓     |
 | PostgreSQL |     ✓     |

--- a/cmd/mangathr/download/download.go
+++ b/cmd/mangathr/download/download.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/browningluke/mangathr/v2/internal/config"
 	"github.com/browningluke/mangathr/v2/internal/downloader"
+	"github.com/browningluke/mangathr/v2/internal/hooks"
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"github.com/browningluke/mangathr/v2/internal/sources"
 	"github.com/browningluke/mangathr/v2/internal/ui"
@@ -87,7 +88,14 @@ func (o *downloadOpts) run(cfg *config.Config) {
 	err = scraper.SelectChapters(chapterSelections)
 	logging.ExitIfError(err)
 
-	scraper.Download(downloader.NewDownloader(downloader.DOWNLOAD, scraper.EnforceChapterDuration()), "")
+	dl := downloader.NewDownloader(downloader.DOWNLOAD, scraper.EnforceChapterDuration()).
+		SetMangaInfo(scraper.MangaTitle(), scraper.ScraperName())
+
+	scraper.Download(dl, "")
+
+	if hookErr := hooks.FinalizeAggregates(); hookErr != nil {
+		logging.Warningln("aggregate hook failed:", hookErr)
+	}
 }
 
 func SelectChapters(titles []string, mangaTitle string, sourceName string) ([]string, error) {

--- a/cmd/mangathr/update/run.go
+++ b/cmd/mangathr/update/run.go
@@ -5,6 +5,7 @@ import (
 	"github.com/browningluke/mangathr/v2/ent"
 	"github.com/browningluke/mangathr/v2/internal/database"
 	"github.com/browningluke/mangathr/v2/internal/downloader"
+	"github.com/browningluke/mangathr/v2/internal/hooks"
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"github.com/browningluke/mangathr/v2/internal/sources"
 	"github.com/browningluke/mangathr/v2/internal/ui"
@@ -31,9 +32,10 @@ func downloadNewChapters(manga *ent.Manga,
 			"\u001B[1mFound:  \u001B[0m%d chapter(s)\n",
 		scraper.MangaTitle(), scraper.ScraperName(), numChapters)
 
-	succeeded := scraper.Download(
-		downloader.NewDownloader(downloader.UPDATE, scraper.EnforceChapterDuration()), manga.Mapping,
-	)
+	dl := downloader.NewDownloader(downloader.UPDATE, scraper.EnforceChapterDuration()).
+		SetMangaInfo(scraper.MangaTitle(), scraper.ScraperName())
+
+	succeeded := scraper.Download(dl, manga.Mapping)
 
 	if !downloader.DryRun() {
 		// If it's not a dry run, add new chapters to db
@@ -51,7 +53,24 @@ func downloadNewChapters(manga *ent.Manga,
 		}
 	}
 
-	return len(succeeded), numChapters - len(succeeded)
+	downloaded = len(succeeded)
+	errors = numChapters - downloaded
+
+	// Fire update.success hook with a summary for this manga.
+	hookCtx := hooks.HookContext{
+		Manga: hooks.MangaContext{
+			Title:  scraper.MangaTitle(),
+			Source: scraper.ScraperName(),
+		},
+		Chapter: hooks.ChapterContext{
+			Count: downloaded,
+		},
+	}
+	if hookErr := hooks.Fire(hooks.EventUpdateSuccess, hookCtx); hookErr != nil {
+		logging.Warningln("update.success hook failed:", hookErr)
+	}
+
+	return
 }
 
 func checkMangaForNewChapters(manga *ent.Manga) (seriesStats, *logging.ScraperError) {
@@ -62,7 +81,14 @@ func checkMangaForNewChapters(manga *ent.Manga) (seriesStats, *logging.ScraperEr
 
 	// Directly search for chapter by ID
 	if err := scraper.SearchByID(manga.MangaID, manga.Title); err != nil {
-		// Abandon search
+		// Fire update.error hook before abandoning
+		hookCtx := hooks.HookContext{
+			Manga: hooks.MangaContext{Title: manga.Title, Source: manga.Source},
+			Error: &hooks.ErrorContext{Message: err.Message},
+		}
+		if hookErr := hooks.Fire(hooks.EventUpdateError, hookCtx); hookErr != nil {
+			logging.Warningln("update.error hook failed:", hookErr)
+		}
 		return seriesStats{}, err
 	}
 
@@ -80,6 +106,14 @@ func checkMangaForNewChapters(manga *ent.Manga) (seriesStats, *logging.ScraperEr
 	// Select new chapters in scraper, get array of them; and download if > 0
 	newChapters, err := scraper.SelectNewChapters(chapterIDs)
 	if err != nil {
+		// Fire update.error hook
+		hookCtx := hooks.HookContext{
+			Manga: hooks.MangaContext{Title: scraper.MangaTitle(), Source: scraper.ScraperName()},
+			Error: &hooks.ErrorContext{Message: err.Message},
+		}
+		if hookErr := hooks.Fire(hooks.EventUpdateError, hookCtx); hookErr != nil {
+			logging.Warningln("update.error hook failed:", hookErr)
+		}
 		return seriesStats{}, err
 	}
 

--- a/cmd/mangathr/update/update.go
+++ b/cmd/mangathr/update/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/browningluke/mangathr/v2/internal/config"
 	"github.com/browningluke/mangathr/v2/internal/database"
+	"github.com/browningluke/mangathr/v2/internal/hooks"
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"github.com/browningluke/mangathr/v2/internal/ui"
 	"github.com/browningluke/mangathr/v2/internal/utils"
@@ -111,4 +112,8 @@ func (o *updateOpts) run(cfg *config.Config) {
 	}
 
 	printStats(stats)
+
+	if err := hooks.FinalizeAggregates(); err != nil {
+		logging.Warningln("aggregate hook failed:", err)
+	}
 }

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -59,3 +59,52 @@ sources:
   mangaplus:
     filenameTemplate: "{num:3} - Chapter {num}{title: - <.>} (mangaplus)" # Set specific for source (overrides global)
     language: 0 # ENGLISH=0, SPANISH=1, FRENCH=2, INDONESIAN=3, PORTUGUESE_BR=4, RUSSIAN=5, THAI=6
+# hooks:
+#   # Discord webhook — fires once at end of update run, even if nothing was downloaded
+#   discord:
+#     - name: "My Discord"
+#       webhookURL: "https://discord.com/api/webhooks/..."
+#       abortOnError: false
+#       fireIfEmpty: true         # fire even when 0 chapters downloaded
+#       on:
+#         - update.success
+#       aggregate: true           # batch all manga into one message
+#       embed: true
+#       template:
+#         title: "mangathr update"
+#         description: |
+#           {{ range .Items }}• {{ .Manga.Title }}: {{ .Chapter.Count }} chapter(s)
+#           {{ end }}
+#         color: 5814783
+#         footer: "mangathr"
+#
+#   # Generic HTTP webhook — fires after each chapter download
+#   webhook:
+#     - name: "My API"
+#       webhookURL: "https://example.com/hook"
+#       requestType: POST
+#       successCode: 200
+#       abortOnError: false
+#       fireIfEmpty: false
+#       on:
+#         - download.chapter
+#       aggregate: false
+#       body: |
+#         {"manga": "{{ .Manga.Title }}", "chapter": "{{ .Chapter.Num }}", "path": "{{ .Chapter.Path }}"}
+#       headers: |
+#         {"Authorization": "Bearer TOKEN"}
+#
+#   # Subcommand — runs a script after each chapter, aborts on failure
+#   subcommand:
+#     - name: "Post-process"
+#       command: "/usr/local/bin/post-process.sh"
+#       abortOnError: true
+#       fireIfEmpty: false
+#       on:
+#         - download.chapter
+#       aggregate: false
+#       args:
+#         - "{{ .Chapter.Path }}"
+#       env:
+#         MANGA_TITLE: "{{ .Manga.Title }}"
+#         CHAPTER_NUM: "{{ .Chapter.Num }}"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/browningluke/mangathr/v2/internal/database"
 	"github.com/browningluke/mangathr/v2/internal/downloader"
+	"github.com/browningluke/mangathr/v2/internal/hooks"
 	"github.com/browningluke/mangathr/v2/internal/sources/cubari"
 	"github.com/browningluke/mangathr/v2/internal/sources/mangadex"
 	"github.com/browningluke/mangathr/v2/internal/sources/mangaplus"
@@ -21,7 +22,8 @@ type Config struct {
 		Cubari    cubari.Config
 		MangaPlus mangaplus.Config
 	}
-	LogLevel string `yaml:"logLevel"`
+	Hooks    hooks.HooksConfig `yaml:"hooks"`
+	LogLevel string            `yaml:"logLevel"`
 }
 
 func (c *Config) Propagate() {
@@ -32,6 +34,8 @@ func (c *Config) Propagate() {
 	mangadex.SetConfig(c.Sources.Mangadex)
 	cubari.SetConfig(c.Sources.Cubari)
 	mangaplus.SetConfig(c.Sources.MangaPlus)
+
+	hooks.SetConfig(c.Hooks)
 }
 
 func (c *Config) Load(path string, inContainer bool) (exists bool, err error) {
@@ -148,6 +152,9 @@ func (c *Config) validate() error {
 	if err := c.Sources.MangaPlus.Validate(); err != nil {
 		return err
 	}
+	if err := validateHooks(c.Hooks); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -159,4 +166,67 @@ func validateMetadataAgent(agent string) bool {
 func validateMetadataLocation(location string) bool {
 	_, exists := utils.FindInSliceFold([]string{"internal", "external", "both"}, location)
 	return exists
+}
+
+var validHookEvents = []string{
+	hooks.EventDownloadChapter,
+	hooks.EventUpdateSuccess,
+	hooks.EventUpdateError,
+}
+
+var validWebhookMethods = []string{"GET", "POST", "PUT", "PATCH"}
+
+func validateHooks(cfg hooks.HooksConfig) error {
+	for _, d := range cfg.Discord {
+		if d.Name == "" {
+			return errors.New("hooks.discord: each hook must have a name")
+		}
+		if d.WebhookURL == "" {
+			return errors.New("hooks.discord: hook " + d.Name + " is missing webhookURL")
+		}
+		if err := validateHookEvents(d.On, "hooks.discord."+d.Name); err != nil {
+			return err
+		}
+	}
+	for _, w := range cfg.Webhook {
+		if w.Name == "" {
+			return errors.New("hooks.webhook: each hook must have a name")
+		}
+		if w.WebhookURL == "" {
+			return errors.New("hooks.webhook: hook " + w.Name + " is missing webhookURL")
+		}
+		if w.RequestType != "" {
+			if _, ok := utils.FindInSliceFold(validWebhookMethods, w.RequestType); !ok {
+				return errors.New("hooks.webhook: hook " + w.Name + " has invalid requestType: " + w.RequestType)
+			}
+		}
+		if err := validateHookEvents(w.On, "hooks.webhook."+w.Name); err != nil {
+			return err
+		}
+	}
+	for _, s := range cfg.Subcommand {
+		if s.Name == "" {
+			return errors.New("hooks.subcommand: each hook must have a name")
+		}
+		if s.Command == "" {
+			return errors.New("hooks.subcommand: hook " + s.Name + " is missing command")
+		}
+		if err := validateHookEvents(s.On, "hooks.subcommand."+s.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateHookEvents(on []string, hookPath string) error {
+	if len(on) == 0 {
+		return errors.New(hookPath + ": on must have at least one event")
+	}
+	for _, e := range on {
+		if _, ok := utils.FindInSliceFold(validHookEvents, e); !ok {
+			return errors.New(hookPath + ": unknown event: " + e +
+				" (valid: download.chapter, update.success, update.error)")
+		}
+	}
+	return nil
 }

--- a/internal/database/driver.go
+++ b/internal/database/driver.go
@@ -65,8 +65,21 @@ func GetDriver() (*Driver, error) {
 		return nil, err
 	}
 
-	// Run the auto migration tool.
-	if config.AutoMigrate {
+	// For SQLite, run migration automatically when the DB file is new (no
+	// existing schema), regardless of the autoMigrate config flag. For all
+	// other drivers, respect the flag explicitly.
+	shouldMigrate := config.AutoMigrate
+	if driverName == dialect.SQLite && !shouldMigrate {
+		// Check whether the schema already exists by counting manga rows.
+		// If the query fails with "no such table", the DB is uninitialised.
+		_, schemaErr := client.Manga.Query().Count(context.Background())
+		if schemaErr != nil && strings.Contains(schemaErr.Error(), "no such table") {
+			logging.Debugln("SQLite database is new, running auto-migration")
+			shouldMigrate = true
+		}
+	}
+
+	if shouldMigrate {
 		logging.Debugln("Running auto-migration")
 		if err := client.Schema.Create(context.Background()); err != nil {
 			return nil, handleConnectionErrors(err)

--- a/internal/database/driver.go
+++ b/internal/database/driver.go
@@ -65,21 +65,8 @@ func GetDriver() (*Driver, error) {
 		return nil, err
 	}
 
-	// For SQLite, run migration automatically when the DB file is new (no
-	// existing schema), regardless of the autoMigrate config flag. For all
-	// other drivers, respect the flag explicitly.
-	shouldMigrate := config.AutoMigrate
-	if driverName == dialect.SQLite && !shouldMigrate {
-		// Check whether the schema already exists by counting manga rows.
-		// If the query fails with "no such table", the DB is uninitialised.
-		_, schemaErr := client.Manga.Query().Count(context.Background())
-		if schemaErr != nil && strings.Contains(schemaErr.Error(), "no such table") {
-			logging.Debugln("SQLite database is new, running auto-migration")
-			shouldMigrate = true
-		}
-	}
-
-	if shouldMigrate {
+	// Run the auto migration tool.
+	if config.AutoMigrate {
 		logging.Debugln("Running auto-migration")
 		if err := client.Schema.Create(context.Background()); err != nil {
 			return nil, handleConnectionErrors(err)

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"github.com/browningluke/mangathr/v2/internal/downloader/workerpool"
 	"github.com/browningluke/mangathr/v2/internal/downloader/writer"
+	"github.com/browningluke/mangathr/v2/internal/hooks"
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"github.com/browningluke/mangathr/v2/internal/manga"
 	"github.com/browningluke/mangathr/v2/internal/metadata"
 	"github.com/browningluke/mangathr/v2/internal/rester"
 	"github.com/browningluke/mangathr/v2/internal/utils"
 	"os"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -26,6 +28,8 @@ type Downloader struct {
 
 	downloadMode    DownloadMode
 	destinationPath string
+	mangaTitle      string
+	mangaSource     string
 
 	enforceChapterDuration bool
 	chapterDuration        int64
@@ -74,6 +78,12 @@ func (d *Downloader) SetMaxRuneCount(chapters []manga.Chapter) *Downloader {
 
 func (d *Downloader) SetPath(path string) *Downloader {
 	d.destinationPath = path
+	return d
+}
+
+func (d *Downloader) SetMangaInfo(title, source string) *Downloader {
+	d.mangaTitle = title
+	d.mangaSource = source
 	return d
 }
 
@@ -137,7 +147,7 @@ func (d *Downloader) DownloadPage(page *manga.Page) ([]byte, error) {
 }
 
 // Download chapter. Assumes CanDownload() has been called and has returned true
-func (d *Downloader) Download(chapter *manga.Chapter) error {
+func (d *Downloader) Download(chapter *manga.Chapter) (retErr error) {
 
 	// Initialize progress bar
 	bar := utils.CreateProgressBar(len(chapter.Pages()), d.maxRuneCount, chapter.Metadata.Num)
@@ -205,6 +215,8 @@ func (d *Downloader) Download(chapter *manga.Chapter) error {
 
 	// Defer cleanup/completion using a closure so it captures poolErr by
 	// reference and sees its final value, not the nil set at declaration.
+	// On success, also fires the download.chapter hook; the named return lets
+	// us propagate a hook error that has abortOnError set.
 	defer func() {
 		if poolErr != nil {
 			// If there were errors, cleanup the writer (only if enabled in config)
@@ -223,6 +235,25 @@ func (d *Downloader) Download(chapter *manga.Chapter) error {
 			// If there were no errors, mark the writer as complete
 			if err := chapterWriter.MarkComplete(); err != nil {
 				logging.Errorln("Unable to mark file as complete. Reason: ", err)
+			}
+
+			// Fire download.chapter hook
+			ctx := hooks.HookContext{
+				Manga: hooks.MangaContext{
+					Title:  d.mangaTitle,
+					Source: d.mangaSource,
+				},
+				Chapter: hooks.ChapterContext{
+					Num:    chapter.Metadata.Num,
+					Title:  chapter.Metadata.Title,
+					Path:   chapterPath,
+					Lang:   chapter.Metadata.Language,
+					Groups: strings.Join(chapter.Metadata.Groups, ", "),
+					Count:  1,
+				},
+			}
+			if hookErr := hooks.Fire(hooks.EventDownloadChapter, ctx); hookErr != nil {
+				retErr = hookErr
 			}
 		}
 	}()

--- a/internal/hooks/controller.go
+++ b/internal/hooks/controller.go
@@ -94,13 +94,17 @@ func (c *Controller) FinalizeAggregates() error {
 		if !h.IsAggregate() {
 			continue
 		}
-		buf, ok := c.buffers[h.Name()]
-		if !ok || len(buf) == 0 {
+
+		buf := c.buffers[h.Name()] // nil/empty if no events were collected
+
+		// If nothing was collected and fireIfEmpty is false, skip entirely.
+		if len(buf) == 0 && !h.FireIfEmpty() {
 			continue
 		}
 
 		aggCtx := buildAggregateContext(buf)
 
+		// If events were collected but total chapters is zero, apply the same gate.
 		if !h.FireIfEmpty() && aggCtx.ChapterCount == 0 {
 			delete(c.buffers, h.Name())
 			continue

--- a/internal/hooks/controller.go
+++ b/internal/hooks/controller.go
@@ -1,0 +1,138 @@
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/browningluke/mangathr/v2/internal/logging"
+)
+
+// HooksConfig is the top-level config struct for all hook types, embedded
+// in the global Config and marshalled from the "hooks" YAML key.
+type HooksConfig struct {
+	Discord    []DiscordHookConfig    `yaml:"discord"`
+	Webhook    []WebhookHookConfig    `yaml:"webhook"`
+	Subcommand []SubcommandHookConfig `yaml:"subcommand"`
+}
+
+// controller is the package-level singleton, initialised via SetConfig.
+var controller *Controller
+
+// SetConfig initialises the package-level controller from cfg.
+func SetConfig(cfg HooksConfig) {
+	controller = newController(cfg)
+}
+
+// Fire dispatches event to all registered hooks. When abortOnError is set on a
+// failing hook, the error is returned and the caller should abort the operation.
+func Fire(event string, ctx HookContext) error {
+	if controller == nil {
+		return nil
+	}
+	return controller.Fire(event, ctx)
+}
+
+// FinalizeAggregates flushes all pending aggregate buffers, firing each hook
+// once with its collected contexts. Call at the end of each command run.
+func FinalizeAggregates() error {
+	if controller == nil {
+		return nil
+	}
+	return controller.FinalizeAggregates()
+}
+
+// Controller manages hook dispatch and aggregate buffering.
+type Controller struct {
+	hooks   []Hook
+	buffers map[string][]HookContext // keyed by hook name
+}
+
+func newController(cfg HooksConfig) *Controller {
+	var hooks []Hook
+	for _, d := range cfg.Discord {
+		hooks = append(hooks, newDiscordHook(d))
+	}
+	for _, w := range cfg.Webhook {
+		hooks = append(hooks, newWebhookHook(w))
+	}
+	for _, s := range cfg.Subcommand {
+		hooks = append(hooks, newSubcommandHook(s))
+	}
+	return &Controller{
+		hooks:   hooks,
+		buffers: make(map[string][]HookContext),
+	}
+}
+
+func (c *Controller) Fire(event string, ctx HookContext) error {
+	ctx.Event = event
+	isError := ctx.Error != nil
+	_ = isError // event name already encodes success/error
+
+	for _, h := range c.hooks {
+		if !h.ShouldFire(event) {
+			continue
+		}
+		if h.IsAggregate() {
+			c.buffers[h.Name()] = append(c.buffers[h.Name()], ctx)
+			continue
+		}
+		if !h.FireIfEmpty() && ctx.Chapter.Count == 0 {
+			continue
+		}
+		if err := h.Fire(ctx); err != nil {
+			if h.AbortOnError() {
+				return fmt.Errorf("hook %q: %w", h.Name(), err)
+			}
+			logging.Warningln(fmt.Sprintf("hook %q failed (abortOnError=false): %v", h.Name(), err))
+		}
+	}
+	return nil
+}
+
+func (c *Controller) FinalizeAggregates() error {
+	for _, h := range c.hooks {
+		if !h.IsAggregate() {
+			continue
+		}
+		buf, ok := c.buffers[h.Name()]
+		if !ok || len(buf) == 0 {
+			continue
+		}
+
+		aggCtx := buildAggregateContext(buf)
+
+		if !h.FireIfEmpty() && aggCtx.ChapterCount == 0 {
+			delete(c.buffers, h.Name())
+			continue
+		}
+
+		if err := h.FireAggregate(aggCtx); err != nil {
+			delete(c.buffers, h.Name())
+			if h.AbortOnError() {
+				return fmt.Errorf("hook %q: %w", h.Name(), err)
+			}
+			logging.Warningln(fmt.Sprintf("hook %q failed (abortOnError=false): %v", h.Name(), err))
+			continue
+		}
+		delete(c.buffers, h.Name())
+	}
+	return nil
+}
+
+func buildAggregateContext(items []HookContext) AggregateHookContext {
+	var chapterCount, errorCount int
+	seen := make(map[string]struct{})
+	for _, ctx := range items {
+		chapterCount += ctx.Chapter.Count
+		if ctx.Error != nil {
+			errorCount++
+		}
+		seen[ctx.Manga.Title] = struct{}{}
+	}
+	return AggregateHookContext{
+		Items:        items,
+		ChapterCount: chapterCount,
+		ErrorCount:   errorCount,
+		MangaCount:   len(seen),
+	}
+}

--- a/internal/hooks/controller.go
+++ b/internal/hooks/controller.go
@@ -125,6 +125,7 @@ func (c *Controller) FinalizeAggregates() error {
 
 func buildAggregateContext(items []HookContext) AggregateHookContext {
 	var chapterCount, errorCount int
+	var event string
 	seen := make(map[string]struct{})
 	for _, ctx := range items {
 		chapterCount += ctx.Chapter.Count
@@ -132,11 +133,15 @@ func buildAggregateContext(items []HookContext) AggregateHookContext {
 			errorCount++
 		}
 		seen[ctx.Manga.Title] = struct{}{}
+		if event == "" {
+			event = ctx.Event
+		}
 	}
 	return AggregateHookContext{
 		Items:        items,
 		ChapterCount: chapterCount,
 		ErrorCount:   errorCount,
 		MangaCount:   len(seen),
+		Event:        event,
 	}
 }

--- a/internal/hooks/discord.go
+++ b/internal/hooks/discord.go
@@ -5,7 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
+
+// discordClient is a dedicated HTTP client for Discord webhook calls, isolated
+// from http.DefaultClient to avoid polluting the global transport state.
+var discordClient = &http.Client{Timeout: 10 * time.Second}
 
 // DiscordHookConfig is the config for a Discord webhook hook.
 type DiscordHookConfig struct {
@@ -115,7 +120,13 @@ func (h *DiscordHook) buildPayload(data any) ([]byte, error) {
 }
 
 func (h *DiscordHook) post(payload []byte) error {
-	resp, err := http.Post(h.cfg.WebhookURL, "application/json", bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, h.cfg.WebhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("hooks: discord %q: build request: %w", h.cfg.Name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := discordClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("hooks: discord %q: request failed: %w", h.cfg.Name, err)
 	}

--- a/internal/hooks/discord.go
+++ b/internal/hooks/discord.go
@@ -1,0 +1,129 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// DiscordHookConfig is the config for a Discord webhook hook.
+type DiscordHookConfig struct {
+	Name         string   `yaml:"name"`
+	WebhookURL   string   `yaml:"webhookURL"`
+	AbortOnError bool     `yaml:"abortOnError"`
+	FireIfEmpty  bool     `yaml:"fireIfEmpty"`
+	On           []string `yaml:"on"`
+	Aggregate    bool     `yaml:"aggregate"`
+	Embed        bool     `yaml:"embed"`
+	Template     struct {
+		// Used when embed: true
+		Title       string `yaml:"title"`
+		Description string `yaml:"description"`
+		Color       int    `yaml:"color"`
+		Footer      string `yaml:"footer"`
+		// Used when embed: false
+		Message string `yaml:"message"`
+	} `yaml:"template"`
+}
+
+type DiscordHook struct {
+	baseHook
+	cfg DiscordHookConfig
+}
+
+func newDiscordHook(cfg DiscordHookConfig) *DiscordHook {
+	return &DiscordHook{
+		baseHook: baseHook{
+			name:         cfg.Name,
+			events:       cfg.On,
+			abortOnError: cfg.AbortOnError,
+			fireIfEmpty:  cfg.FireIfEmpty,
+			aggregate:    cfg.Aggregate,
+		},
+		cfg: cfg,
+	}
+}
+
+func (h *DiscordHook) Fire(ctx HookContext) error {
+	return h.send(ctx)
+}
+
+func (h *DiscordHook) FireAggregate(ctx AggregateHookContext) error {
+	return h.send(ctx)
+}
+
+func (h *DiscordHook) send(data any) error {
+	payload, err := h.buildPayload(data)
+	if err != nil {
+		return fmt.Errorf("hooks: discord %q: build payload: %w", h.cfg.Name, err)
+	}
+	return h.post(payload)
+}
+
+// discordEmbedPayload is the JSON envelope for embed-style messages.
+type discordEmbedPayload struct {
+	Embeds []discordEmbed `json:"embeds"`
+}
+
+type discordEmbed struct {
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Color       int            `json:"color,omitempty"`
+	Footer      *discordFooter `json:"footer,omitempty"`
+}
+
+type discordFooter struct {
+	Text string `json:"text"`
+}
+
+type discordMessagePayload struct {
+	Content string `json:"content"`
+}
+
+func (h *DiscordHook) buildPayload(data any) ([]byte, error) {
+	if h.cfg.Embed {
+		title, err := renderTemplate(h.cfg.Template.Title, data)
+		if err != nil {
+			return nil, err
+		}
+		desc, err := renderTemplate(h.cfg.Template.Description, data)
+		if err != nil {
+			return nil, err
+		}
+		footer, err := renderTemplate(h.cfg.Template.Footer, data)
+		if err != nil {
+			return nil, err
+		}
+
+		embed := discordEmbed{
+			Title:       title,
+			Description: desc,
+			Color:       h.cfg.Template.Color,
+		}
+		if footer != "" {
+			embed.Footer = &discordFooter{Text: footer}
+		}
+		return json.Marshal(discordEmbedPayload{Embeds: []discordEmbed{embed}})
+	}
+
+	msg, err := renderTemplate(h.cfg.Template.Message, data)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(discordMessagePayload{Content: msg})
+}
+
+func (h *DiscordHook) post(payload []byte) error {
+	resp, err := http.Post(h.cfg.WebhookURL, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("hooks: discord %q: request failed: %w", h.cfg.Name, err)
+	}
+	defer resp.Body.Close()
+
+	// Discord returns 204 No Content on success.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("hooks: discord %q: unexpected status %d", h.cfg.Name, resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/hooks/hook.go
+++ b/internal/hooks/hook.go
@@ -1,0 +1,39 @@
+package hooks
+
+import "strings"
+
+// Hook is implemented by each hook type (discord, webhook, subcommand).
+type Hook interface {
+	Name() string
+	IsAggregate() bool
+	AbortOnError() bool
+	FireIfEmpty() bool
+	ShouldFire(event string) bool
+
+	Fire(ctx HookContext) error
+	FireAggregate(ctx AggregateHookContext) error
+}
+
+// baseHook provides the shared fields and method implementations that all
+// hook types embed to satisfy the non-send parts of the Hook interface.
+type baseHook struct {
+	name         string
+	events       []string
+	abortOnError bool
+	fireIfEmpty  bool
+	aggregate    bool
+}
+
+func (b *baseHook) Name() string        { return b.name }
+func (b *baseHook) IsAggregate() bool   { return b.aggregate }
+func (b *baseHook) AbortOnError() bool  { return b.abortOnError }
+func (b *baseHook) FireIfEmpty() bool   { return b.fireIfEmpty }
+
+func (b *baseHook) ShouldFire(event string) bool {
+	for _, e := range b.events {
+		if strings.EqualFold(e, event) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/hooks/subcommand.go
+++ b/internal/hooks/subcommand.go
@@ -1,0 +1,90 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// SubcommandHookConfig is the config for a subcommand hook.
+type SubcommandHookConfig struct {
+	Name         string            `yaml:"name"`
+	Command      string            `yaml:"command"`
+	AbortOnError bool              `yaml:"abortOnError"`
+	FireIfEmpty  bool              `yaml:"fireIfEmpty"`
+	On           []string          `yaml:"on"`
+	Aggregate    bool              `yaml:"aggregate"`
+	Args         []string          `yaml:"args"` // each entry is a text/template
+	Env          map[string]string `yaml:"env"`  // values are text/templates
+}
+
+type SubcommandHook struct {
+	baseHook
+	cfg SubcommandHookConfig
+}
+
+func newSubcommandHook(cfg SubcommandHookConfig) *SubcommandHook {
+	return &SubcommandHook{
+		baseHook: baseHook{
+			name:         cfg.Name,
+			events:       cfg.On,
+			abortOnError: cfg.AbortOnError,
+			fireIfEmpty:  cfg.FireIfEmpty,
+			aggregate:    cfg.Aggregate,
+		},
+		cfg: cfg,
+	}
+}
+
+func (h *SubcommandHook) Fire(ctx HookContext) error {
+	return h.run(ctx)
+}
+
+func (h *SubcommandHook) FireAggregate(ctx AggregateHookContext) error {
+	return h.run(ctx)
+}
+
+func (h *SubcommandHook) run(data any) error {
+	args, err := h.renderArgs(data)
+	if err != nil {
+		return fmt.Errorf("hooks: subcommand %q: render args: %w", h.cfg.Name, err)
+	}
+
+	env, err := h.renderEnv(data)
+	if err != nil {
+		return fmt.Errorf("hooks: subcommand %q: render env: %w", h.cfg.Name, err)
+	}
+
+	cmd := exec.Command(h.cfg.Command, args...)
+	cmd.Env = append(os.Environ(), env...)
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("hooks: subcommand %q failed: %w\nOutput: %s",
+			h.cfg.Name, err, output)
+	}
+	return nil
+}
+
+func (h *SubcommandHook) renderArgs(data any) ([]string, error) {
+	args := make([]string, 0, len(h.cfg.Args))
+	for _, tmpl := range h.cfg.Args {
+		rendered, err := renderTemplate(tmpl, data)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, rendered)
+	}
+	return args, nil
+}
+
+func (h *SubcommandHook) renderEnv(data any) ([]string, error) {
+	env := make([]string, 0, len(h.cfg.Env))
+	for k, tmpl := range h.cfg.Env {
+		rendered, err := renderTemplate(tmpl, data)
+		if err != nil {
+			return nil, err
+		}
+		env = append(env, k+"="+rendered)
+	}
+	return env, nil
+}

--- a/internal/hooks/template.go
+++ b/internal/hooks/template.go
@@ -1,0 +1,19 @@
+package hooks
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// renderTemplate executes a text/template string against data and returns the result.
+func renderTemplate(tmpl string, data any) (string, error) {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/hooks/types.go
+++ b/internal/hooks/types.go
@@ -1,0 +1,46 @@
+package hooks
+
+// Event name constants.
+const (
+	EventDownloadChapter = "download.chapter"
+	EventUpdateSuccess   = "update.success"
+	EventUpdateError     = "update.error"
+)
+
+// MangaContext holds per-manga template data.
+type MangaContext struct {
+	Title  string
+	Source string
+}
+
+// ChapterContext holds per-chapter template data.
+type ChapterContext struct {
+	Num    string
+	Title  string
+	Path   string // filesystem path where the chapter was saved
+	Lang   string
+	Groups string // comma-separated group names
+	Count  int    // total chapters downloaded in this run (1 for single-event hooks)
+}
+
+// ErrorContext holds error template data; nil when there is no error.
+type ErrorContext struct {
+	Message string
+}
+
+// HookContext is the template context for non-aggregate hook invocations.
+type HookContext struct {
+	Manga   MangaContext
+	Chapter ChapterContext
+	Error   *ErrorContext // nil on success
+	Event   string
+}
+
+// AggregateHookContext is the template context when aggregate: true.
+type AggregateHookContext struct {
+	Items        []HookContext
+	ChapterCount int
+	ErrorCount   int
+	MangaCount   int
+	Event        string
+}

--- a/internal/hooks/webhook.go
+++ b/internal/hooks/webhook.go
@@ -1,0 +1,105 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// WebhookHookConfig is the config for a generic HTTP webhook hook.
+type WebhookHookConfig struct {
+	Name         string            `yaml:"name"`
+	WebhookURL   string            `yaml:"webhookURL"`
+	RequestType  string            `yaml:"requestType"`  // GET/POST/PUT/PATCH; default POST
+	SuccessCode  int               `yaml:"successCode"`  // default 200
+	AbortOnError bool              `yaml:"abortOnError"`
+	FireIfEmpty  bool              `yaml:"fireIfEmpty"`
+	On           []string          `yaml:"on"`
+	Aggregate    bool              `yaml:"aggregate"`
+	Body         string            `yaml:"body"`    // text/template → JSON body
+	Headers      string            `yaml:"headers"` // text/template → JSON map of headers
+}
+
+type WebhookHook struct {
+	baseHook
+	cfg WebhookHookConfig
+}
+
+func newWebhookHook(cfg WebhookHookConfig) *WebhookHook {
+	if cfg.RequestType == "" {
+		cfg.RequestType = "POST"
+	}
+	if cfg.SuccessCode == 0 {
+		cfg.SuccessCode = 200
+	}
+	return &WebhookHook{
+		baseHook: baseHook{
+			name:         cfg.Name,
+			events:       cfg.On,
+			abortOnError: cfg.AbortOnError,
+			fireIfEmpty:  cfg.FireIfEmpty,
+			aggregate:    cfg.Aggregate,
+		},
+		cfg: cfg,
+	}
+}
+
+func (h *WebhookHook) Fire(ctx HookContext) error {
+	return h.send(ctx)
+}
+
+func (h *WebhookHook) FireAggregate(ctx AggregateHookContext) error {
+	return h.send(ctx)
+}
+
+func (h *WebhookHook) send(data any) error {
+	body, err := renderTemplate(h.cfg.Body, data)
+	if err != nil {
+		return fmt.Errorf("hooks: webhook %q: render body: %w", h.cfg.Name, err)
+	}
+
+	headers, err := h.renderHeaders(data)
+	if err != nil {
+		return fmt.Errorf("hooks: webhook %q: render headers: %w", h.cfg.Name, err)
+	}
+
+	method := strings.ToUpper(h.cfg.RequestType)
+	req, err := http.NewRequest(method, h.cfg.WebhookURL, bytes.NewBufferString(body))
+	if err != nil {
+		return fmt.Errorf("hooks: webhook %q: build request: %w", h.cfg.Name, err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("hooks: webhook %q: request failed: %w", h.cfg.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != h.cfg.SuccessCode {
+		return fmt.Errorf("hooks: webhook %q: unexpected status %d (want %d)",
+			h.cfg.Name, resp.StatusCode, h.cfg.SuccessCode)
+	}
+	return nil
+}
+
+func (h *WebhookHook) renderHeaders(data any) (map[string]string, error) {
+	if h.cfg.Headers == "" {
+		return nil, nil
+	}
+	rendered, err := renderTemplate(h.cfg.Headers, data)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(rendered), &result); err != nil {
+		return nil, fmt.Errorf("parse rendered headers as JSON: %w", err)
+	}
+	return result, nil
+}

--- a/internal/rester/rester.go
+++ b/internal/rester/rester.go
@@ -1,12 +1,9 @@
 package rester
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -34,11 +31,6 @@ func New() *RESTer {
 			Transport: &http.Transport{
 				MaxConnsPerHost: 50,
 				MaxIdleConns:    50 * 3,
-				DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-					tlsConfig := http.DefaultTransport.(*http.Transport).TLSClientConfig
-					conn, err := tls.Dial(network, addr, tlsConfig)
-					return conn, err
-				},
 			},
 			Timeout: time.Second * 50,
 		},


### PR DESCRIPTION
Adds lifecycle hooks that fire during `download` and `update` commands.

**Three hook types:**
- `discord` — embed or plain-message Discord webhooks
- `webhook` — generic HTTP webhook (GET/POST/PUT/PATCH) with templated body/headers
- `subcommand` — run a local command with templated args and env vars

**Events:** `download.chapter`, `update.success`, `update.error`

**Per-hook options:** `on`, `aggregate`, `abortOnError`, `fireIfEmpty`

Templates use Go's `text/template`. Context exposes manga title/source, chapter num/title/path/lang/groups/count, and error message. Aggregate context wraps all collected items with totals.

Config example added to `examples/config.yml`.