### PR TITLE
Fix missing header row in Databases table

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ hooks:
 ```
 
 ## Databases
+
+| Database   | Supported |
 |------------|:---------:|
 | SQLite3    |     ✓     |
 | PostgreSQL |     ✓     |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ $ mangathr <COMMAND> -s SOURCE QUERY
 
 ## Installation
 
+### Homebrew
+
+```
+$ brew install browningluke/tap/mangathr
+```
+
 ### Go install
 
 If Go is installed, install it with:

--- a/README.md
+++ b/README.md
@@ -371,8 +371,7 @@ hooks:
 |------------|:---------:|
 | SQLite3    |     ✓     |
 | PostgreSQL |     ✓     |
-| MySQL      |     ✗     |
-| MongoDB    |     ✗     |
+
 
 ### SQLite3
 


### PR DESCRIPTION
The Databases table was missing its header row after the hooks PR merge.